### PR TITLE
Added Sentry information to privacy policy

### DIFF
--- a/templates/privacy-policy.jade
+++ b/templates/privacy-policy.jade
@@ -30,8 +30,9 @@ html(lang='en')
       h1 Avalanche Forecasts App Privacy Policy
       p In order to provide our App's services, we must collect some personal information. Protecting your personal information is very important to us. This policy explains what information we collect and how we use it.
       h2 What information do we collect and how is it used?
-      p When the App requests forecast information from our web servers, our web servers log the request and store the IP address the request was made from. These logs are used for tracking usage as well as maintaining the performance and stability of the web servers. The logs are deleted after 1 year. We share the logs with service providers who also use the information for tracking usage and maintaining the performance and stability of the servers.
+      p When the App requests forecast information from our web servers, our web servers log the request and store the IP address the request was made from. These logs are used for tracking usage as well as maintaining the performance and stability of the web servers. We share the logs with service providers who also use the information for tracking usage and maintaining the performance and stability of the servers.
       p The App also requests your current location. Your location is used to center the map the first time you open it. We don't store your location.
+      p For some kinds of error conditions, the App may send information about the error to Sentry which is a third party service to manage error handling. This information only includes information about the error and doesn't include any personally identifiable information about your device.
       h3 Web browser within the App
       p When you click on a specific zone in the map, the app shows a web page from a third party website. You can also follow links to other websites. Please see those websites' privacy policies for any information about they may be collecting when you visit those sites from within the App.
 


### PR DESCRIPTION
We are using Sentry to help with errors and so we need to add
information about what gets sent to Sentry to the privacy policy.

I also removed the bit about deleting logs after 1 year to match the
policy in the app.