### PR TITLE
Updated for NWACs move to AFP

### DIFF
--- a/forecasts.js
+++ b/forecasts.js
@@ -324,8 +324,8 @@ forecasts.getRegionDetailsForRegionId = function(regionId) {
             var parser = null;
             switch (components[0]) {
                 case 'nwac':
-                    dataURL = 'https://www.nwac.us/api/v2/avalanche-region-forecast/?format=json&limit=1&zone=' + components[1];
-                    parser = forecasts.parseForecast_nwac;
+                    dataURL = 'https://api.avalanche.org/v1/forecast/get-map-data/NWAC';
+                    parser = forecasts.parseForecast_avalanche_org_api;
                     break;
                 case 'cac':
                     // CAC South Coast has two polygons that have the same forecast; handle that

--- a/public/v1/regions.json
+++ b/public/v1/regions.json
@@ -1,6 +1,6 @@
 [
     {
-        "regionId": "nwac_olympics",
+        "regionId": "nwac_139",
         "displayName": "Olympics",
         "URL": "https://www.nwac.us/avalanche-forecast/current/olympics",
         "points": [
@@ -107,7 +107,7 @@
             ]
     },
     {
-        "regionId": "nwac_cascade-west-stevens-pass",
+        "regionId": "nwac_140",
         "displayName": "Stevens Pass",
         "URL": "https://www.nwac.us/avalanche-forecast/current/cascade-west-stevens-pass/",
         "points": [
@@ -186,7 +186,7 @@
             ]
     },
     {
-        "regionId": "nwac_cascade-west-snoqualmie-pass",
+        "regionId": "nwac_141",
         "displayName": "Snoqualmie Pass",
         "URL": "https://www.nwac.us/avalanche-forecast/current/cascade-west-snoqualmie-pass/",
         "points": [
@@ -285,7 +285,7 @@
             ]
     },
     {
-        "regionId": "nwac_cascade-west-north-baker",
+        "regionId": "nwac_142",
         "displayName": "WA Cascades West, Mt Baker",
         "URL": "https://www.nwac.us/avalanche-forecast/current/cascade-west-north-baker/",
         "points": [
@@ -428,7 +428,7 @@
             ]
     },
     {
-        "regionId": "nwac_cascade-west-central",
+        "regionId": "nwac_143",
         "displayName": "WA Cascades West, Central",
         "URL": "https://www.nwac.us/avalanche-forecast/current/cascade-west-central/",
         "points": [
@@ -671,7 +671,7 @@
             ]
     },
     {
-        "regionId": "nwac_cascade-west-south",
+        "regionId": "nwac_144",
         "displayName": "WA Cascades West, South",
         "URL": "https://www.nwac.us/avalanche-forecast/current/cascade-west-south/",
         "points": [
@@ -814,7 +814,7 @@
             ]
     },
     {
-        "regionId": "nwac_cascade-east-north",
+        "regionId": "nwac_145",
         "displayName": "WA Cascades East, North",
         "URL": "https://www.nwac.us/avalanche-forecast/current/cascade-east-north/",
         "points": [
@@ -1089,7 +1089,7 @@
             ]
     },
     {
-        "regionId": "nwac_cascade-east-central",
+        "regionId": "nwac_146",
         "displayName": "WA Cascades East, Central",
         "URL": "https://www.nwac.us/avalanche-forecast/current/cascade-east-central/",
         "points": [
@@ -1420,7 +1420,7 @@
             ]
     },
     {
-        "regionId": "nwac_cascade-east-south",
+        "regionId": "nwac_147",
         "displayName": "WA Cascades East, South",
         "URL": "https://www.nwac.us/avalanche-forecast/current/cascade-east-south/",
         "points": [
@@ -1543,7 +1543,7 @@
             ]
     },
     {
-        "regionId": "nwac_mt-hood",
+        "regionId": "nwac_148",
         "displayName": "Mt Hood",
         "URL": "https://www.nwac.us/avalanche-forecast/current/mt-hood/",
         "points": [

--- a/region_definition/nwac/nwac_regions.json
+++ b/region_definition/nwac/nwac_regions.json
@@ -1,6 +1,6 @@
 [
     {
-        "regionId": "nwac_olympics",
+        "regionId": "nwac_139",
         "displayName": "Olympics",
         "URL": "http://www.nwac.us/avalanche-forecast/current/olympics/",
         "points": [
@@ -63,7 +63,7 @@
         ]
     },
     {
-        "regionId": "nwac_cascade-west-stevens-pass",
+        "regionId": "nwac_140",
         "displayName": "Stevens Pass",
         "URL": "http://www.nwac.us/avalanche-forecast/current/cascade-west-stevens-pass/",
         "points": [
@@ -98,7 +98,7 @@
         ]
     },
     {
-        "regionId": "nwac_cascade-west-snoqualmie-pass",
+        "regionId": "nwac_141",
         "displayName": "Snoqualmie Pass",
         "URL": "http://www.nwac.us/avalanche-forecast/current/cascade-west-snoqualmie-pass/",
         "points": [
@@ -137,7 +137,7 @@
         ]
     },
     {
-        "regionId": "nwac_cascade-west-north-baker",
+        "regionId": "nwac_142",
         "displayName": "WA Cascades West, Mt Baker",
         "URL": "http://www.nwac.us/avalanche-forecast/current/cascade-west-north-baker/",
         "points": [
@@ -248,7 +248,7 @@
         ]
     },
     {
-        "regionId": "nwac_cascade-west-central",
+        "regionId": "nwac_143",
         "displayName": "WA Cascades West, Central",
         "URL": "http://www.nwac.us/avalanche-forecast/current/cascade-west-central/",
         "points": [
@@ -419,7 +419,7 @@
         ]
     },
     {
-        "regionId": "nwac_cascade-west-south",
+        "regionId": "nwac_144",
         "displayName": "WA Cascades West, South",
         "URL": "http://www.nwac.us/avalanche-forecast/current/cascade-west-south/",
         "points": [
@@ -522,7 +522,7 @@
         ]
     },
     {
-        "regionId": "nwac_cascade-east-north",
+        "regionId": "nwac_145",
         "displayName": "WA Cascades East, North",
         "URL": "http://www.nwac.us/avalanche-forecast/current/cascade-east-north/",
         "points": [
@@ -661,7 +661,7 @@
         ]
     },
     {
-        "regionId": "nwac_cascade-east-central",
+        "regionId": "nwac_146",
         "displayName": "WA Cascades East, Central",
         "URL": "http://www.nwac.us/avalanche-forecast/current/cascade-east-central/",
         "points": [
@@ -908,7 +908,7 @@
         ]
     },
     {
-        "regionId": "nwac_cascade-east-south",
+        "regionId": "nwac_147",
         "displayName": "WA Cascades East, South",
         "URL": "http://www.nwac.us/avalanche-forecast/current/cascade-east-south/",
         "points": [
@@ -1031,7 +1031,7 @@
         ]
     },
     {
-        "regionId": "nwac_mt-hood",
+        "regionId": "nwac_148",
         "displayName": "Mt Hood",
         "URL": "http://www.nwac.us/avalanche-forecast/current/mt-hood/",
         "points": [


### PR DESCRIPTION
NWAC is now using the AFP for their avalanche forecasts.