### PR TITLE
Update Bridger Teton to use the NAC parser and data.

### DIFF
--- a/forecasts.js
+++ b/forecasts.js
@@ -365,8 +365,8 @@ forecasts.getRegionDetailsForRegion = function(region) {
                     parser = forecasts.parseForecast_avalanche_org_api;
                     break;
                 case 'btac':
-                    dataURL = forecasts.getDataURL_btac(components[1]);
-                    parser = forecasts.parseForecast_simple_caaml;
+                    dataURL = 'https://api.avalanche.org/v1/forecast/get-map-data/BTAC'                    
+                    parser = forecasts.parseForecast_avalanche_org_api;
                     break;
                 case 'wcmac':
                     dataURL = 'https://api.avalanche.org/v1/forecast/get-map-data/WCMAC';
@@ -523,29 +523,6 @@ forecasts.getDataURL_caic = function(subregion) {
             break;
         default:
             winston.warn('getDataURL_caic: no match for subregion: ' + subregion);
-            break;
-    }
-
-    return dataURL;
-};
-
-forecasts.getDataURL_btac = function(subregion) {
-
-    var dataURL = null;
-    var baseURL = 'https://www.jhavalanche.org/media/xml/';
-
-    switch (subregion) {
-        case '1':
-            dataURL = baseURL + 'teton_Avalanche_Forecast.xml';
-            break;
-        case '2':
-            dataURL = baseURL + 'tog_Avalanche_Forecast.xml';
-            break;
-        case '3':
-            dataURL = baseURL + 'grey_Avalanche_Forecast.xml';
-            break;
-        default:
-            winston.warn('getDataURL_btac: no match for subregion: ' + subregion);
             break;
     }
 

--- a/region_definition/btac/btac.json
+++ b/region_definition/btac/btac.json
@@ -1,8 +1,8 @@
 [
     {
-        "regionId": "btac_teton",
+        "regionId": "btac_896",
         "displayName": "Teton",
-        "URL": "http://jhavalanche.org/viewOther?area=teton",
+        "URL": "https://bridgertetonavalanchecenter.org/forecasts/#/tetons",
         "points": [
             {
                 "lat": "44.13302967660224",
@@ -671,9 +671,9 @@
         ]
     },
     {
-        "regionId": "btac_tog",
+        "regionId": "btac_898",
         "displayName": "Togwotee Pass",
-        "URL": "http://jhavalanche.org/viewOther?area=tog",
+        "URL": "https://bridgertetonavalanchecenter.org/forecasts/#/togwotee-pass",
         "points": [
             {
                 "lat": "43.22002209057887",
@@ -5814,9 +5814,9 @@
         ]
     },
     {
-        "regionId": "btac_grey",
+        "regionId": "btac_897",
         "displayName": "Greys River",
-        "URL": "http://jhavalanche.org/viewOther?area=grey",
+        "URL": "https://bridgertetonavalanchecenter.org/forecasts/#/greys-river",
         "points": [
             {
                 "lat": "43.57043897092824",

--- a/region_definition/btac/btac_simplified.json
+++ b/region_definition/btac/btac_simplified.json
@@ -1,8 +1,8 @@
 [
     {
-        "regionId": "btac_teton",
+        "regionId": "btac_896",
         "displayName": "Teton",
-        "URL": "http://jhavalanche.org/viewOther?area=teton",
+        "URL": "https://bridgertetonavalanchecenter.org/forecasts/#/tetons",
         "points": [
             {
                 "lat": "44.133",
@@ -159,9 +159,9 @@
         ]
     },
     {
-        "regionId": "btac_tog",
+        "regionId": "btac_898",
         "displayName": "Togwotee Pass",
-        "URL": "http://jhavalanche.org/viewOther?area=tog",
+        "URL": "https://bridgertetonavalanchecenter.org/forecasts/#/togwotee-pass",
         "points": [
             {
                 "lat": "43.220",
@@ -450,9 +450,9 @@
         ]
     },
     {
-        "regionId": "btac_grey",
+        "regionId": "btac_897",
         "displayName": "Greys River",
-        "URL": "http://jhavalanche.org/viewOther?area=grey",
+        "URL": "https://bridgertetonavalanchecenter.org/forecasts/#/greys-river",
         "points": [
             {
                 "lat": "43.570",

--- a/test/test.js
+++ b/test/test.js
@@ -331,11 +331,11 @@ describe('parseForecast_simple_caaml caic', function(){
         })
     })
 })
-
+/* DISABLE BTAC test since it is now on NAC parser
 describe('parseForecast_simple_caaml btac', function(){
     describe('file001.xml', function(){
         it('should return the correct forecast details', function(){
-            var forecast = forecasts.parseForecast_simple_caaml(fs.readFileSync('test/data/btac/file001.xml','utf8'),
+            var forecast = forecasts.parseForecast_simple_caaml(fs.readFileSync('test/data/btac/////file001.xml','utf8'),
                 forecasts.getRegionDetailsForRegionId('btac_teton'));
 
             should.exist(forecast);
@@ -356,6 +356,7 @@ describe('parseForecast_simple_caaml btac', function(){
         })
     })
 })
+*/
 
 describe('parseForecast_avalanche_org_api nwac', function(){
     describe('file001.json', function(){


### PR DESCRIPTION
The BTAC changed its site this year to use the NAC products. 